### PR TITLE
Add JFR tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+.gradle
+.jdk
+.jib
+.classpath
+.idea
+.project
+.settings
+*.iml
+build/
+out/
+bin/
+target/
+*~

--- a/README.md
+++ b/README.md
@@ -6,3 +6,15 @@ Java applications that use JFR API for testing purposes
 ```
 mvn clean package
 ```
+
+## Run test class (com.redhat.jfr.tests.*)
+
+```
+java -cp target/classes <fully-qualified-name>
+```
+
+For example:
+
+```
+java -cp target/classes com.redhat.jfr.tests.event.TestConcurrentEvents
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # jfr-tests
 Java applications that use JFR API for testing purposes
+
+## Compile
+
+```
+mvn clean package
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,65 @@
+<!--
+/*
+ * Copyright (c) 2020, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.redhat.jfr</groupId>
+  <artifactId>graalvm-jfr-tests</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>graalvm-jfr-tests</name>
+  <url>http://maven.apache.org</url>
+
+  <build>
+    <plugins>
+      <plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-compiler-plugin</artifactId>
+	<version>3.8.1</version>
+	<configuration>
+        <verbose>true</verbose>
+        <fork>true</fork>
+        <executable>/usr/lib/jvm/java-11-openjdk/bin/javac</executable>
+        <compilerVersion>11</compilerVersion>
+        <source>11</source>
+        <target>11</target>
+        <release>11</release>
+        </configuration>
+      </plugin>
+      <plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-source-plugin</artifactId>
+	<version>2.1.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/main/java/com/redhat/jfr/events/EventTypePrototype.java
+++ b/src/main/java/com/redhat/jfr/events/EventTypePrototype.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.redhat.jfr.events;
+
+import jdk.jfr.AnnotationElement;
+import jdk.jfr.Name;
+import jdk.jfr.ValueDescriptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class EventTypePrototype {
+    private final List<ValueDescriptor> fields;
+    private final List<AnnotationElement> annotations;
+    private final String name;
+
+    public EventTypePrototype(String name, List<AnnotationElement> as, List<ValueDescriptor> fields) {
+        this.annotations = new ArrayList<>(as);
+        this.annotations.add(new AnnotationElement(Name.class, name));
+        this.fields = fields;
+        this.name = name;
+    }
+
+    public int getFieldIndex(String key) {
+        int index = 0;
+        for (ValueDescriptor f : fields) {
+            if (f.getName().equals(key)) {
+                return index;
+            }
+            index++;
+        }
+        throw new NoSuchFieldError(key);
+    }
+
+    public void addField(ValueDescriptor fieldDescriptor) {
+        fields.add(fieldDescriptor);
+    }
+
+    public void addAnnotation(AnnotationElement annotation) {
+        annotations.add(annotation);
+    }
+
+    public List<ValueDescriptor> getFields() {
+        return fields;
+    }
+
+    public List<AnnotationElement> getAnnotations() {
+        return annotations;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/redhat/jfr/events/StringEvent.java
+++ b/src/main/java/com/redhat/jfr/events/StringEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.redhat.jfr.events;
+
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.StackTrace;
+
+@Label("String Event")
+@Description("An event with a string payload")
+@StackTrace(false)
+public class StringEvent extends Event {
+
+    @Label("Message")
+    public String message;
+}

--- a/src/main/java/com/redhat/jfr/events/TimestampedEvent.java
+++ b/src/main/java/com/redhat/jfr/events/TimestampedEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.redhat.jfr.events;
+
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Timestamp;
+
+@Label("Timestamp Event")
+@Description("A general event with just a message and a timestamp as payload")
+public class TimestampedEvent extends Event {
+
+    @Label("Message")
+    public String message;
+
+    @Timestamp
+    public long timestamp;
+}

--- a/src/main/java/com/redhat/jfr/events/annotated/EnabledEvent.java
+++ b/src/main/java/com/redhat/jfr/events/annotated/EnabledEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.redhat.jfr.events.annotated;
+
+import jdk.jfr.*;
+
+@Name("EnabledEvent")
+@Label("Enabled Event")
+@Category("Java Application")
+@Description("An event with just the Enabled annotation")
+@Enabled(false)
+@StackTrace(false)
+public class EnabledEvent extends Event {
+}

--- a/src/main/java/com/redhat/jfr/events/annotated/RegisteredEvent.java
+++ b/src/main/java/com/redhat/jfr/events/annotated/RegisteredEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.redhat.jfr.events.annotated;
+
+import jdk.jfr.Registered;
+
+@Registered()
+public class RegisteredEvent extends EnabledEvent {
+}

--- a/src/main/java/com/redhat/jfr/events/annotated/UnregisteredEvent.java
+++ b/src/main/java/com/redhat/jfr/events/annotated/UnregisteredEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.redhat.jfr.events.annotated;
+
+import jdk.jfr.Event;
+import jdk.jfr.Registered;
+
+@Registered(false)
+public class UnregisteredEvent extends Event {
+}

--- a/src/main/java/com/redhat/jfr/tests/event/TestConcurrentEvents.java
+++ b/src/main/java/com/redhat/jfr/tests/event/TestConcurrentEvents.java
@@ -1,0 +1,35 @@
+package com.redhat.jfr.tests.event;
+
+import com.redhat.jfr.events.StringEvent;
+import com.redhat.jfr.utils.JFR;
+import com.redhat.jfr.utils.LocalJFR;
+import com.redhat.jfr.utils.Stressor;
+
+import java.io.File;
+
+public class TestConcurrentEvents {
+
+    public static void main(String[] args) throws Exception {
+        long s0 = System.currentTimeMillis();
+        JFR jfr = new LocalJFR();
+        int threadCount = 8;
+        long id = jfr.startRecording("TestConcurrentEvents");
+
+        Runnable r = () -> {
+            int count = 1024 * 1024;
+            for (int i = 0; i < count; i++) {
+                StringEvent event = new StringEvent();
+                event.message = "Event has been generated!";
+                event.commit();
+            }
+        };
+        Thread.UncaughtExceptionHandler eh = (t, e) -> e.printStackTrace();
+        Stressor.execute(threadCount, eh, r);
+
+        File recording = jfr.endRecording(id);
+
+        long d0 = System.currentTimeMillis() - s0;
+        System.out.println("elapsed:" + d0);
+        System.err.println("jfr recording: " + recording);
+    }
+}

--- a/src/main/java/com/redhat/jfr/tests/event/TestMultipleEvents.java
+++ b/src/main/java/com/redhat/jfr/tests/event/TestMultipleEvents.java
@@ -1,0 +1,31 @@
+package com.redhat.jfr.tests.event;
+
+import com.redhat.jfr.events.StringEvent;
+import com.redhat.jfr.utils.JFR;
+import com.redhat.jfr.utils.LocalJFR;
+
+import java.io.File;
+
+public class TestMultipleEvents {
+
+    public static void main(String[] args) throws Exception {
+        long s0 = System.currentTimeMillis();
+        JFR jfr = new LocalJFR();
+        long id = jfr.startRecording("TestMultipleEvents");
+
+        int count = 1024 * 1024;
+
+
+        for (int i = 0; i < count; i++) {
+            StringEvent event = new StringEvent();
+            event.message = "Event has been generated!";
+            event.commit();
+        }
+
+        File recording = jfr.endRecording(id);
+
+        long d0 = System.currentTimeMillis() - s0;
+        System.out.println("elapsed:" + d0);
+        System.err.println("jfr recording: " + recording);
+    }
+}

--- a/src/main/java/com/redhat/jfr/tests/event/TestSingleEvent.java
+++ b/src/main/java/com/redhat/jfr/tests/event/TestSingleEvent.java
@@ -30,6 +30,7 @@ import java.io.File;
 public class TestSingleEvent {
 
     public static void main(String[] args) throws Exception {
+        long s0 = System.currentTimeMillis();
         JFR jfr = new LocalJFR();
         long id = jfr.startRecording("TestSingleEvent");
 
@@ -38,6 +39,8 @@ public class TestSingleEvent {
         event.commit();
 
         File recording = jfr.endRecording(id);
+        long d0 = System.currentTimeMillis() - s0;
+        System.out.println("elapsed:" + d0);
         System.err.println("jfr recording: " + recording);
     }
 }

--- a/src/main/java/com/redhat/jfr/tests/event/TestSingleEvent.java
+++ b/src/main/java/com/redhat/jfr/tests/event/TestSingleEvent.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.redhat.jfr.tests.event;
+
+import com.redhat.jfr.events.StringEvent;
+import com.redhat.jfr.utils.JFR;
+import com.redhat.jfr.utils.LocalJFR;
+
+import java.io.File;
+
+public class TestSingleEvent {
+
+    public static void main(String[] args) throws Exception {
+        JFR jfr = new LocalJFR();
+        long id = jfr.startRecording("TestSingleEvent");
+
+        StringEvent event = new StringEvent();
+        event.message = "Event has been generated!";
+        event.commit();
+
+        File recording = jfr.endRecording(id);
+        System.err.println("jfr recording: " + recording);
+    }
+}

--- a/src/main/java/com/redhat/jfr/tests/event/TestSingleEventClean.java
+++ b/src/main/java/com/redhat/jfr/tests/event/TestSingleEventClean.java
@@ -26,8 +26,12 @@ import com.redhat.jfr.events.StringEvent;
 public class TestSingleEventClean {
 
     public static void main(String[] args) throws Exception {
+        long s0 = System.currentTimeMillis();
         StringEvent event = new StringEvent();
         event.message = "Event has been generated!";
         event.commit();
+
+        long d0 = System.currentTimeMillis() - s0;
+        System.out.println("elapsed:" + d0);
     }
 }

--- a/src/main/java/com/redhat/jfr/tests/event/TestSingleEventClean.java
+++ b/src/main/java/com/redhat/jfr/tests/event/TestSingleEventClean.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.redhat.jfr.tests.event;
+
+import com.redhat.jfr.events.StringEvent;
+
+public class TestSingleEventClean {
+
+    public static void main(String[] args) throws Exception {
+        StringEvent event = new StringEvent();
+        event.message = "Event has been generated!";
+        event.commit();
+    }
+}

--- a/src/main/java/com/redhat/jfr/tests/recording/TestConsecutiveRecordings.java
+++ b/src/main/java/com/redhat/jfr/tests/recording/TestConsecutiveRecordings.java
@@ -1,0 +1,39 @@
+package com.redhat.jfr.tests.recording;
+
+import com.redhat.jfr.events.StringEvent;
+import jdk.jfr.Recording;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class TestConsecutiveRecordings {
+    public static void main(String[] args) throws IOException {
+        String name = "One";
+        Recording r = new Recording();
+        Path destination = File.createTempFile(name, ".jfr").toPath();
+        r.setDestination(destination);
+
+        r.start();
+        for (int i = 0; i < 2; i++) {
+            StringEvent event = new StringEvent();
+            event.message = "Event has been generated!";
+            event.commit();
+        }
+        r.stop();
+        r.close();
+
+        name = "Two";
+        r = new Recording();
+        r.start();
+        for (int i = 0; i < 2; i++) {
+            StringEvent event = new StringEvent();
+            event.message = "Event has been generated!";
+            event.commit();
+        }
+        r.stop();
+        destination = File.createTempFile(name, ".jfr").toPath();
+        r.dump(destination);
+        r.close();
+    }
+}

--- a/src/main/java/com/redhat/jfr/tests/recording/TestConsecutiveRecordings.java
+++ b/src/main/java/com/redhat/jfr/tests/recording/TestConsecutiveRecordings.java
@@ -9,10 +9,11 @@ import java.nio.file.Path;
 
 public class TestConsecutiveRecordings {
     public static void main(String[] args) throws IOException {
+        long s0 = System.currentTimeMillis();
         String name = "One";
         Recording r = new Recording();
-        Path destination = File.createTempFile(name, ".jfr").toPath();
-        r.setDestination(destination);
+        Path destination1 = File.createTempFile(name, ".jfr").toPath();
+        r.setDestination(destination1);
 
         r.start();
         for (int i = 0; i < 2; i++) {
@@ -32,8 +33,13 @@ public class TestConsecutiveRecordings {
             event.commit();
         }
         r.stop();
-        destination = File.createTempFile(name, ".jfr").toPath();
-        r.dump(destination);
+        Path destination2 = File.createTempFile(name, ".jfr").toPath();
+        r.dump(destination2);
         r.close();
+
+        long d0 = System.currentTimeMillis() - s0;
+        System.out.println("elapsed:" + d0);
+        System.err.println("jfr recording: " + destination1);
+        System.err.println("jfr recording: " + destination2);
     }
 }

--- a/src/main/java/com/redhat/jfr/tests/recording/TestInterspersedRecordings.java
+++ b/src/main/java/com/redhat/jfr/tests/recording/TestInterspersedRecordings.java
@@ -1,0 +1,43 @@
+package com.redhat.jfr.tests.recording;
+
+import com.redhat.jfr.events.StringEvent;
+import jdk.jfr.Recording;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class TestInterspersedRecordings {
+    public static void main(String[] args) throws IOException {
+        String nameOne = "One";
+        Recording r1 = new Recording();
+        Path destination = File.createTempFile(nameOne, ".jfr").toPath();
+        r1.setDestination(destination);
+
+        String nameTwo = "Two";
+        Recording r2 = new Recording();
+
+        r1.start();
+        r2.start();
+
+        for (int i = 0; i < 2; i++) {
+            StringEvent event = new StringEvent();
+            event.message = "Event has been generated!";
+            event.commit();
+        }
+
+        r1.stop();
+        r1.close();
+
+        for (int i = 0; i < 2; i++) {
+            StringEvent event = new StringEvent();
+            event.message = "Event has been generated!";
+            event.commit();
+        }
+
+        r2.stop();
+        destination = File.createTempFile(nameTwo, ".jfr").toPath();
+        r2.dump(destination);
+        r2.close();
+    }
+}

--- a/src/main/java/com/redhat/jfr/tests/recording/TestInterspersedRecordings.java
+++ b/src/main/java/com/redhat/jfr/tests/recording/TestInterspersedRecordings.java
@@ -9,10 +9,11 @@ import java.nio.file.Path;
 
 public class TestInterspersedRecordings {
     public static void main(String[] args) throws IOException {
+        long s0 = System.currentTimeMillis();
         String nameOne = "One";
         Recording r1 = new Recording();
-        Path destination = File.createTempFile(nameOne, ".jfr").toPath();
-        r1.setDestination(destination);
+        Path destination1 = File.createTempFile(nameOne, ".jfr").toPath();
+        r1.setDestination(destination1);
 
         String nameTwo = "Two";
         Recording r2 = new Recording();
@@ -36,8 +37,13 @@ public class TestInterspersedRecordings {
         }
 
         r2.stop();
-        destination = File.createTempFile(nameTwo, ".jfr").toPath();
-        r2.dump(destination);
+        Path destination2 = File.createTempFile(nameTwo, ".jfr").toPath();
+        r2.dump(destination2);
         r2.close();
+
+        long d0 = System.currentTimeMillis() - s0;
+        System.out.println("elapsed:" + d0);
+        System.err.println("jfr recording: " + destination1);
+        System.err.println("jfr recording: " + destination2);
     }
 }

--- a/src/main/java/com/redhat/jfr/utils/JFR.java
+++ b/src/main/java/com/redhat/jfr/utils/JFR.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.redhat.jfr.utils;
+
+import java.io.File;
+
+/**
+ * Utility class to handle recording.
+ */
+public interface JFR {
+    long startRecording(String recordingName) throws Exception;
+
+    long startRecording(String recordingName, String configName) throws Exception;
+
+    File endRecording(long id) throws Exception;
+}

--- a/src/main/java/com/redhat/jfr/utils/LocalJFR.java
+++ b/src/main/java/com/redhat/jfr/utils/LocalJFR.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.redhat.jfr.utils;
+
+import jdk.jfr.Configuration;
+import jdk.jfr.Recording;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+public class LocalJFR implements JFR {
+    private final Map<Long, Recording> recordings = new HashMap<>();
+
+    @Override
+    public long startRecording(String recordingName) throws Exception {
+        return startRecording(new Recording(), recordingName);
+    }
+
+    @Override
+    public long startRecording(String recordingName, String configName) throws Exception {
+        Configuration c = Configuration.getConfiguration(configName);
+        return startRecording(new Recording(c), recordingName);
+    }
+
+    public File endRecording(long id) throws Exception {
+        Recording recording = recordings.remove(id);
+        recording.stop();
+        recording.close();
+        return recording.getDestination().toFile();
+    }
+
+    public long startRecording(Recording recording, String name) throws Exception {
+        long id = recording.getId();
+
+        Path destination = File.createTempFile(name + "-" + id, ".jfr").toPath();
+        recording.setDestination(destination);
+
+        recordings.put(id, recording);
+
+        recording.start();
+        return id;
+    }
+}

--- a/src/main/java/com/redhat/jfr/utils/Stressor.java
+++ b/src/main/java/com/redhat/jfr/utils/Stressor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.redhat.jfr.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class to help run multiple threads executing some task
+ *
+ * @since 1.9
+ */
+public class Stressor {
+    public static void execute(int numberOfThreads, Thread.UncaughtExceptionHandler eh, Runnable task) throws Exception {
+        List<Thread> threads = new ArrayList<>();
+        for (int n = 0; n < numberOfThreads; ++n) {
+            Thread t = new Thread(task);
+            t.setUncaughtExceptionHandler(eh);
+            threads.add(t);
+            t.start();
+        }
+        for (Thread t : threads) {
+            t.join();
+        }
+    }
+}


### PR DESCRIPTION
Adds a basic set of tests to exercise the JFR API.

Co-authored by: Andrew Dinn <adinn@redhat.com>
Co-authored by: Roman Kennke <rkennke@redhat.com>
Co-authored by: Mario Torre <neugens@redhat.com>